### PR TITLE
Add react-router-dom and web-audio-daw modules to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-addons-test-utils": "^15.4.2",
     "react-redux": "^5.0.2",
     "react-router": "^3.0.2",
+    "react-router-dom": "^4.0.0",
     "redux": "^3.6.0",
     "redux-logger": "^3.0.1",
     "sass-loader": "^4.1.1",
@@ -63,6 +64,8 @@
     "react-redux": "^5.0.3",
     "react-router-redux": "^5.0.0-alpha.4",
     "redux": "^3.6.0",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "web-audio-daw": "^2.3.1"
+
   }
 }


### PR DESCRIPTION
These were missing from the node modules and causing errors when starting up the server. They are in package.json now so just `npm i`