### PR TITLE
add pitch modifiers to each step

### DIFF
--- a/lib/components/Sequencer/SequencerComponents/TrackRack.jsx
+++ b/lib/components/Sequencer/SequencerComponents/TrackRack.jsx
@@ -5,8 +5,8 @@ import Slider from '../../SoundMaker/Slider'
 const TrackRack = (props) => {
   return(
     <div className="single-rack">
-      <div>
-        <div className="sample-name">{props.name}</div>
+      <div className='extended-controls'>
+        <span>volume</span>
         <Slider
           value={props.volume}
           id={'track-volume'}
@@ -16,17 +16,31 @@ const TrackRack = (props) => {
           max={1}
           step={.01}
         />
-      </div>
-      {props.steps.map((step, i) =>
-        <TrackStep
-          key={i}
-          index={i}
-          step={step}
-          name={props.name}
-          currentStep={props.currentStep}
-          toggleStep={props.toggleStep}
+        <span>filter</span>
+        <Slider
+          value={props.filter}
+          id={'track-filter'}
+          type='range'
+          handleChange={(e)=>props.changeFilter(props.name, e.target.value)}
+          min={0}
+          max={5000}
+          step={10}
         />
-      )}
+      </div>
+      <div className='basic-controls'>
+        <div className="sample-name">{props.name}</div>
+        {props.steps.map((step, i) =>
+          <TrackStep
+            key={i}
+            index={i}
+            step={step}
+            name={props.name}
+            currentStep={props.currentStep}
+            toggleStep={props.toggleStep}
+            changePitch={props.changePitch}
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/lib/components/Sequencer/SequencerComponents/TrackStep.jsx
+++ b/lib/components/Sequencer/SequencerComponents/TrackStep.jsx
@@ -3,9 +3,18 @@ import React from 'react';
 const TrackStep = (props) => {
   return(
     <div className={props.currentStep === props.index ? "single-step current" : "single-step"}>
-      <div className={props.step ? 'step-on' : 'step-off'}
+      <div className={props.step.play ? 'step-on' : 'step-off'}
            onClick={() => props.toggleStep(props.name, props.index)}
-        >hey</div>
+        >
+        hey
+      </div>
+      <div className={"step-pitch"}>
+        <input className="pitch-input"
+               type='text'
+               value={props.step.pitch}
+               onChange={(e)=> props.changePitch(props.name, props.index, e.target.value)}
+        />
+      </div>
     </div>
   )
 }

--- a/lib/components/Sequencer/index.jsx
+++ b/lib/components/Sequencer/index.jsx
@@ -14,10 +14,11 @@ export class Sequencer extends Component {
       tempo: 200,
       trackRacks: {
         snare:{
-          steps:[true,false,false,false,true,false,false,false,true,false,false,false,true,false,false,false],
+          steps:[{play:true, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:true, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:true, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:true, pitch:''},{play:false, pitch:''},{play:false, pitch:''},{play:false, pitch:''}],
           sound:{
            source : 'noise',
            volume: .5,
+           pitch: 'A4',
             env : {
                 attack : .001,
                 decay : .12,
@@ -26,17 +27,18 @@ export class Sequencer extends Component {
                 release : .02
             },
             filter : {
-                type : 'bandpass',
+                type : 'highpass',
                 frequency : 300,
                 q : .180
             }
           }
         },
         snap:{
-          steps:[true,true,true,true,true,true,true,true,true,true,true,true,true,true,true,true],
+          steps:[{play:true, pitch:"A5"},{play:true, pitch:'B5'},{play:true, pitch:'C5'},{play:true, pitch:'D5'},{play:true, pitch:'E5'},{play:true, pitch:'D5'},{play:true, pitch:'C5'},{play:true, pitch:'B5'},{play:true, pitch:''},{play:true, pitch:''},{play:true, pitch:''},{play:true, pitch:''},{play:true, pitch:''},{play:true, pitch:''},{play:true, pitch:''},{play:true, pitch:''}],
           sound:{
            source : 'sine',
            volume: .5,
+           pitch: 'A4',
             env : {
                 attack : .001,
                 decay : .12,
@@ -45,7 +47,7 @@ export class Sequencer extends Component {
                 release : .02
             },
             filter : {
-                type : 'bandpass',
+                type : 'highpass',
                 frequency : 300,
                 q : .180
             }
@@ -71,9 +73,10 @@ export class Sequencer extends Component {
   playStep() {
     if (this.state.playPause) {
       Object.keys(this.state.trackRacks).forEach((key)=>{
-        if(this.state.trackRacks[key].steps[this.state.currentStep]){
+        if(this.state.trackRacks[key].steps[this.state.currentStep].play){
           let wad = new Wad (this.state.trackRacks[key].sound)
-          wad.play()
+          let pitch = (this.state.trackRacks[key].steps[this.state.currentStep].pitch !== '') ? this.state.trackRacks[key].steps[this.state.currentStep].pitch : this.state.trackRacks[key].sound.pitch
+          wad.play({pitch: pitch})
         }
       })
       if (this.state.currentStep < 15) {
@@ -86,12 +89,25 @@ export class Sequencer extends Component {
 
   toggleStep(key, index) {
     let newRack = this.state.trackRacks
-    newRack[key].steps[index] = !newRack[key].steps[index]
+    newRack[key].steps[index].play = !newRack[key].steps[index].play
     this.setState({ trackRacks: newRack })
   }
+
   changeVolume(key, newVolume) {
     let newRack = this.state.trackRacks
     newRack[key].sound.volume = parseFloat(newVolume)
+    this.setState({ trackRacks: newRack })
+  }
+
+  changeFilter(key, newFreq) {
+    let newRack = this.state.trackRacks
+    newRack[key].sound.filter.frequency = parseFloat(newFreq)
+    this.setState({ trackRacks: newRack })
+  }
+
+  changePitch(key, index, newPitch) {
+    let newRack = this.state.trackRacks
+    newRack[key].steps[index].pitch = newPitch.toUpperCase()
     this.setState({ trackRacks: newRack })
   }
 
@@ -110,10 +126,13 @@ export class Sequencer extends Component {
             <TrackRack key={i}
                        name={trackRack}
                        volume={this.state.trackRacks[trackRack].sound.volume}
+                       filter={this.state.trackRacks[trackRack].sound.filter.frequency}
                        steps={this.state.trackRacks[trackRack].steps}
                        currentStep={this.state.currentStep}
                        toggleStep={this.toggleStep.bind(this)}
                        changeVolume={this.changeVolume.bind(this)}
+                       changeFilter={this.changeFilter.bind(this)}
+                       changePitch={this.changePitch.bind(this)}
             />
           )}
         </div>

--- a/lib/components/Sequencer/sequencer-style.scss
+++ b/lib/components/Sequencer/sequencer-style.scss
@@ -5,6 +5,7 @@ $main-color: #fff;
   border: 1px solid black;
   display: flex;
   flex-direction: column;
+
   #play-controls {
     display: flex;
     flex-direction: row;
@@ -21,18 +22,30 @@ $main-color: #fff;
 
 .single-rack {
   display: flex;
-  flex-direction: row;
+  flex-direction: column-reverse;
   border: 1px solid green;
   margin: 5px;
   .sample-name {
+    width: 40px;
     border: 1px solid teal;
     margin: 5px;
   }
 }
 
+.extended-controls {
+  display: flex;
+  flex-direction: row
+}
+
+.basic-controls {
+  display: flex;
+  flex-direction: row
+}
+
 .single-step {
   border: 1px solid yellowgreen;
   margin: 5px;
+  width: 40px;
   .step-on {
     background: magenta;
     margin: 5px;
@@ -45,4 +58,8 @@ $main-color: #fff;
 
 .current {
   background-color: red;
+}
+
+.pitch-input {
+  width: 30px;
 }


### PR DESCRIPTION
switch steps from simple boolean to object with a key for the play boolean and a separate key for pitch. if left empty, the WAD play defaults to the pitch defined in the sound constructor. 