### PR TITLE
Remove Tuna effects, console logs, and use Prompt to prevent state transition

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,27 +1,30 @@
 import { push } from 'react-router-redux'
+// import Wad from 'web-audio-daw'
 import Wad from '../../vendor/wad.js'
 
-export const previewSound = (options) => (dispatch, getState) => {
-  dispatch(stopSound())
-
-  const sound = new Wad(options)
+export const previewSound = (spec) => (dispatch, getState) => {
+  const sound = new Wad(spec)
+  const { sounds } = getState()
+  if (sounds.length !== 0) {
+    dispatch(stopSound())
+  }
 
   dispatch({
     type: 'PUSH_SOUND',
     sound,
   })
 
-  dispatch(playSound(sound))
+  return dispatch(playSound(sound))
 }
 
-export const createSound = (options) => {
-  const sound = new Wad(options)
+// export const createSound = (options) => {
+//   // const sound = new Wad(options)
 
-  return {
-    type: 'CREATE_SOUND',
-    sound,
-  }
-}
+//   return {
+//     type: 'CREATE_SOUND',
+//     sound,
+//   }
+// }
 
 export const playSound = (sound) => {
   sound.play()
@@ -48,8 +51,10 @@ export const stopSound = () => (dispatch, getState) => {
     const sound = sounds[soundArrayLength - 1]
 
     sound.stop()
+    // sound.audioContext.close()
+    // Wad.audioContext.close()
 
-    dispatch({
+    return dispatch({
       type: 'POP_SOUND',
     })
   }

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -4,8 +4,7 @@ import Select from './Select'
 import Slider from './Slider'
 import update from 'immutability-helper'
 import Button from '../Button'
-
-import Toggle from 'react-toggle'
+// import Toggle from 'react-toggle'
 
 
 export class SoundMaker extends Component {
@@ -39,120 +38,23 @@ export class SoundMaker extends Component {
           wet: 1,
           impulse: 'http://localhost:3000/api/v1/impulses?id=BlockInside.wav',
         },
-        // delay: {
-        //   delayTime: 0.5,
-        //   wet: 0.25,
-        //   feedback: 0.25,
-        // },
+        delay: {
+          delayTime: 0.5,
+          wet: 0.25,
+          feedback: 0.25,
+        },
         vibrato: {
           shape: 'sine',
           magnitude: 3,
           speed: 4,
           attack: 0,
         },
-        // tremolo: {
-        //   shape: 'sine',
-        //   magnitude: 3,
-        //   speed: 4,
-        //   attack: 0,
-        // },
-        tuna: {
-          Chorus: {
-            rate: 1.5,          // 0.01 to 8+
-            feedback: 0.2,      // 0 to 1+
-            delay: 0.0045,      // 0 to 1
-            bypass: 1,          // the value 1 starts the effect as bypassed, 0 or 1
-          },
-          Delay: {
-            feedback: 0.45,    // 0 to 1+
-            delayTime: 150,    // 1 to 10000 milliseconds
-            wetLevel: 0.25,    // 0 to 1+
-            dryLevel: 1,       // 0 to 1+
-            cutoff: 2000,      // cutoff frequency of the built in lowpass-filter. 20 to 22050
-            bypass: 1,
-          },
-          Overdrive: {
-            outputGain: 0.5,         // 0 to 1+
-            drive: 0.7,              // 0 to 1
-            curveAmount: 1,          // 0 to 1
-            algorithmIndex: 0,       // 0 to 5, selects one of our drive algorithms
-            bypass: 1,
-          },
-          Phaser: {
-            rate: 1.2,                     // 0.01 to 8 is a decent rangbut higher values are possible
-            depth: 0.3,                    // 0 to 1
-            feedback: 0.2,                 // 0 to 1+
-            stereoPhase: 30,               // 0 to 180
-            baseModulationFrequency: 700,  // 500 to 1500
-            bypass: 1,
-          },
-          Compressor: {
-            threshold: -1,     // -100 to 0
-            makeupGain: 1,     // 0 and up (in decibels)
-            attack: 1,         // 0 to 1000
-            release: 0,        // 0 to 3000
-            ratio: 4,          // 1 to 20
-            knee: 5,           // 0 to 40
-            automakeup: 1,  // true/false
-            bypass: 1,
-          },
-          // Convolver: {
-          //   highCut: 22050,    // 20 to 22050
-          //   lowCut: 20,        // 20 to 22050
-          //   dryLevel: 1,       // 0 to 1+
-          //   wetLevel: 1,       // 0 to 1+
-          //   level: 1,          // 0 to 1+, adjusts total output of both wet and dry
-          //   impulse: 'http://localhost:3000/api/v1/impulses?id=BlockInside.wav',
-          //   bypass: 1,
-          // },
-          // Filter: {
-          //   frequency: 440,        // :4 to 22050
-          //   Q: 1,                  // 0.001 to 100
-          //   gain: 0,               // -40 to 40 (in decibels)
-          //   filterType: 'lowpass', // lowpass, highpass, bandpass, lowshelf, highshelf, peaking, notch, allpass 
-          //   bypass: 1,
-          // // },
-          // Cabinet: {
-          //   makeupGain: 1,                                 // 0 to 20
-          //   impulsePath: 'http://localhost:3000/api/v1/impulses?id=DirectCabinetN1.wav',    // path to your speaker impulse
-          //   bypass: 1,
-          // },
-          Tremolo: {
-            intensity: 0.3,    // 0 to 1
-            rate: 4,           // 0.001 to 8
-            stereoPhase: 0,    // 0 to 180
-            bypass: 1,
-          },
-          WahWah: {
-            automode: true,        // true/false
-            baseFrequency: 0.5,    // 0 to 1
-            excursionOctaves: 2,   // 1 to 6
-            sweep: 0.2,            // 0 to 1
-            resonance: 10,         // 1 to 100
-            sensitivity: 0.5,      // -1 to 1
-            bypass: 1,
-          },
-          Bitcrusher: {
-            bits: 4,           // 1 to 16
-            normfreq: 0.1,     // 0 to 1
-            bufferSize: 4096,  // 256 to 16384
-            bypass: 1,
-          },
-          MoogFilter: {
-            cutoff: 0.065,     // 0 to 1
-            resonance: 3.5,    // 0 to 4
-            bufferSize: 4096,  // 256 to 16384
-            bypass: 1,
-          },
-          PingPongDelay: {
-            wetLevel: 0.5,       // 0 to 1
-            feedback: 0.3,       // 0 to 1
-            delayTimeLeft: 150,  // 1 to 10000 (milliseconds)
-            delayTimeRight: 200, // 1 to 10000 (milliseconds)
-            bypass: 1,
-          },
+        tremolo: {
+          shape: 'sine',
+          magnitude: 3,
+          speed: 4,
+          attack: 0,
         },
-        oscillators: [],
       },
     }
   }
@@ -217,12 +119,12 @@ export class SoundMaker extends Component {
     this.setState(update(this.state, { spec: { vibrato: { [key]: { $set: this.round(target.value, 4) } } } }))
   }
 
-  updateTunaBypass = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { [key]: { bypass: { $set: parseInt(target.value, 10) } } } } }))
+  updateDelay = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { delay: { [key]: { $set: this.round(target.value, 4) } } } }))
   }
 
-  updateTuna = (effect, property) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { [effect]: { [property]: { $set: this.round(target.value, 4) } } } } }))
+  updateTremolo = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tremolo: { [key]: { $set: this.round(target.value, 4) } } } }))
   }
 
   render() {
@@ -437,7 +339,7 @@ export class SoundMaker extends Component {
         </div>
         <div className='lfo-container'>
           <h2> LFOs </h2>
-          {/* <div className='delay'>
+          <div className='delay'>
             <h4> Delay </h4>
             <Slider
               label='Delay Time'
@@ -446,7 +348,7 @@ export class SoundMaker extends Component {
               min={0}
               max={2}
               step={0.01}
-              handleChange={updateDelay('delayTime')}
+              handleChange={this.updateDelay('delayTime')}
               value={this.state.spec.delay.delayTime}
             />
             <Slider
@@ -456,7 +358,7 @@ export class SoundMaker extends Component {
               min={0}
               max={1}
               step={0.01}
-              handleChange={updateDelay('wet')}
+              handleChange={this.updateDelay('wet')}
               value={this.state.spec.delay.wet}
             />
             <Slider
@@ -466,10 +368,10 @@ export class SoundMaker extends Component {
               min={0}
               max={1}
               step={0.01}
-              handleChange={updateDelay('feedback')}
+              handleChange={this.updateDelay('feedback')}
               value={this.state.spec.delay.feedback}
             />
-          </div> */}
+          </div>
           <div className='vibrato'>
             <h4> Vibrato </h4>
             <Select
@@ -509,7 +411,7 @@ export class SoundMaker extends Component {
               value={this.state.spec.vibrato.attack}
             />
           </div>
-          {/* <div className='tremolo'>
+          <div className='tremolo'>
             <h4> Tremolo </h4>
             <Select
               name='tremolo-shape'
@@ -547,515 +449,8 @@ export class SoundMaker extends Component {
               handleChange={this.updateTremolo('attack')}
               value={this.state.spec.tremolo.attack}
             />
-          </div>*/}
-        </div>
-          <div className='tuna'>
-            <h2>Tuna</h2>
-            <div className='tuna-chorus'>
-              <h4> Chorus </h4>
-              <Slider
-                label='Rate'
-                className='slider tuna-chorus-rate'
-                id='slider-tuna-chorus-rate'
-                min={0}
-                max={8}
-                step={0.1}
-                handleChange={this.updateTuna('Chorus', 'rate')}
-                value={this.state.spec.tuna.Chorus.rate}
-              />
-              <Slider
-                label='Feedback'
-                className='slider tuna-chorus-feedback'
-                id='slider-tuna-chorus-feedback'
-                min={0}
-                max={1}
-                step={0.01}
-                handleChange={this.updateTuna('Chorus', 'feedback')}
-                value={this.state.spec.tuna.Chorus.feedback}
-              />
-              <Slider
-                label='Delay'
-                className='slider tuna-chorus-delay'
-                id='slider-tuna-chorus-delay'
-                min={0}
-                max={1}
-                step={0.01}
-                handleChange={this.updateTuna('Chorus', 'delay')}
-                value={this.state.spec.tuna.Chorus.delay}
-              />
-              <Slider
-                label='Bypass'
-                className='slider tuna-chorus-bypass'
-                id='slider-tuna-chorus-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Chorus')}
-                value={this.state.spec.tuna.Chorus.bypass}
-              />
-            </div>
-            <div className='tuna-delay'>
-              <h4> Delay </h4>
-              <Slider
-                label='Feedback'
-                className='slider tuna-delay-feedback'
-                id='slider-tuna-tuna-delay-feedback'
-                min={0}
-                max={1}
-                step={0.10}
-                handleChange={this.updateTuna('Delay', 'feedback')}
-                value={this.state.spec.tuna.Delay.feedback}
-              />
-              <Slider
-                label='Delay Time'
-                className='slider tuna-delay-delay-time'
-                id='slider-tuna-tuna-delay-delay-time'
-                min={1}
-                max={10000}
-                step={1}
-                handleChange={this.updateTuna('Delay', 'delayTime')}
-                value={this.state.spec.tuna.Delay.delayTime}
-              />
-              <Slider
-                label='Wet Level'
-                className='slider tuna-delay-wet-level'
-                id='slider-tuna-tuna-delay-wet-level'
-                min={0}
-                max={1}
-                step={0.10}
-                handleChange={this.updateTuna('Delay', 'wetLevel')}
-                value={this.state.spec.tuna.Delay.wetLevel}
-              />
-              <Slider
-                label='Dry Level'
-                className='slider tuna-delay-dry-level'
-                id='slider-tuna-tuna-delay-dry-level'
-                min={0}
-                max={1}
-                step={0.10}
-                handleChange={this.updateTuna('Delay', 'dryLevel')}
-                value={this.state.spec.tuna.Delay.dryLevel}
-              />
-              <Slider
-                label='Cutoff'
-                className='slider tuna-delay-cutoff'
-                id='slider-tuna-tuna-delay-cutoff'
-                min={20}
-                max={22050}
-                step={1}
-                handleChange={this.updateTuna('Delay', 'cutoff')}
-                value={this.state.spec.tuna.Delay.cutoff}
-              />
-              <Slider
-                label='Bypass'
-                className='slider tuna-delay-bypass'
-                id='slider-tuna-delay-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Delay')}
-                value={this.state.spec.tuna.Delay.bypass}
-              />
-            </div>
-            <div className='tuna-phaser'>
-              <h4> Phaser </h4>
-              <Slider
-                label='Rate'
-                className='slider tuna-phaser-rate'
-                id='slider-tuna-phaser-rate'
-                min={0.1}
-                max={8}
-                step={0.1}
-                handleChange={this.updateTuna('Phaser', 'rate')}
-                value={this.state.spec.tuna.Phaser.rate}
-              />
-              <Slider
-                label='Depth'
-                className='slider tuna-phaser-depth'
-                id='slider-tuna-phaser-depth'
-                min={0}
-                max={1}
-                step={0.1}
-                handleChange={this.updateTuna('Phaser', 'depth')}
-                value={this.state.spec.tuna.Phaser.depth}
-              />
-              <Slider
-                label='Feedback'
-                className='slider tuna-phaser-feedback'
-                id='slider-tuna-phaser-feedback'
-                min={0}
-                max={1}
-                step={0.01}
-                handleChange={this.updateTuna('Phaser', 'feedback')}
-                value={this.state.spec.tuna.Phaser.feedback}
-              />
-              <Slider
-                label='stereoPhase'
-                className='slider tuna-phaser-stereo-phase'
-                id='slider-tuna-phaser-stereo-phase'
-                min={0}
-                max={180}
-                step={1}
-                handleChange={this.updateTuna('Phaser', 'stereoPhase')}
-                value={this.state.spec.tuna.Phaser.stereoPhase}
-              />
-              <Slider
-                label='baseModulationFrequency'
-                className='slider tuna-phaser-base-modulation-frequency'
-                id='slider-tuna-phaser-base-modulation-frequency'
-                min={500}
-                max={1500}
-                step={1}
-                handleChange={this.updateTuna('Phaser', 'baseModulationFrequency')}
-                value={this.state.spec.tuna.Phaser.baseModulationFrequency}
-              />
-              <Slider
-                label='Bypass'
-                className='slider tuna-phaser-bypass'
-                id='slider-tuna-phaser-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Phaser')}
-                value={this.state.spec.tuna.Phaser.bypass}
-              />
-            </div>
-            <div className='tuna-overdrive'>
-              <h4> Overdrive </h4>
-              <Slider
-                label='Output Gain'
-                className='slider tuna-overdrive-output-gain'
-                id='slider-tuna-overdrive-output-gain'
-                min={0}
-                max={1}
-                step={0.01}
-                handleChange={this.updateTuna('Overdrive', 'outputGain')}
-                value={this.state.spec.tuna.Overdrive.outputGain}
-              />
-              <Slider
-                label='Drive'
-                className='slider tuna-overdrive-drive'
-                id='slider-tuna-overdrive-drive'
-                min={0}
-                max={1}
-                step={0.01}
-                handleChange={this.updateTuna('Overdrive', 'drive')}
-                value={this.state.spec.tuna.Overdrive.drive}
-              />
-              <Slider
-                label='Curve Amount'
-                className='slider tuna-overdrive-curve-amount'
-                id='slider-tuna-overdrive-curve-amount'
-                min={0}
-                max={1}
-                step={0.01}
-                handleChange={this.updateTuna('Overdrive', 'curveAmount')}
-                value={this.state.spec.tuna.Overdrive.curveAmount}
-              />
-              <Slider
-                label='Algorithm Index'
-                className='slider tuna-overdrive-algorithm-index'
-                id='slider-tuna-overdrive-algorithm-index'
-                min={0}
-                max={5}
-                step={1}
-                handleChange={this.updateTuna('Overdrive', 'algorithmIndex')}
-                value={this.state.spec.tuna.Overdrive.algorithmIndex}
-              />
-              <Slider
-                label='Bypass'
-                className='slider tuna-overdrive-bypass'
-                id='slider-tuna-overdrive-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Overdrive')}
-                value={this.state.spec.tuna.Overdrive.bypass}
-              />
-            </div>
-            <div className='tuna-compressor'>
-              <h4> Compressor </h4>
-              <Slider
-                label='Threshold'
-                className='slider tuna-compressor-threshold'
-                id='slider-tuna-compressor-threshold'
-                min={-100}
-                max={0}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'threshold')}
-                value={this.state.spec.tuna.Compressor.threshold}
-              />
-              <Slider
-                label='Makeup Gain'
-                className='slider tuna-compressor-makeup-gain'
-                id='slider-tuna-compressor-makeup-gain'
-                min={0}
-                max={10}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'makeupGain')}
-                value={this.state.spec.tuna.Compressor.makeupGain}
-              />
-              <Slider
-                label='Attack'
-                className='slider tuna-compressor-attack'
-                id='slider-tuna-compressor-attack'
-                min={0}
-                max={1000}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'attack')}
-                value={this.state.spec.tuna.Compressor.attack}
-              />
-              <Slider
-                label='Release'
-                className='slider tuna-compressor-release'
-                id='slider-tuna-compressor-release'
-                min={0}
-                max={10}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'release')}
-                value={this.state.spec.tuna.Compressor.release}
-              />
-              <Slider
-                label='ratio'
-                className='slider tuna-compressor-ratio'
-                id='slider-tuna-compressor-ratio'
-                min={1}
-                max={20}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'ratio')}
-                value={this.state.spec.tuna.Compressor.ratio}
-              />
-              <Slider
-                label='knee'
-                className='slider tuna-compressor-knee'
-                id='slider-tuna-compressor-knee'
-                min={0}
-                max={40}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'knee')}
-                value={this.state.spec.tuna.Compressor.knee}
-              />
-              <Slider
-                label='automakeup'
-                className='slider tuna-compressor-automakeup'
-                id='slider-tuna-compressor-automakeup'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTuna('Compressor', 'automakeup')}
-                value={this.state.spec.tuna.Compressor.automakeup}
-              />
-              <Slider
-                label='Bypass'
-                className='slider tuna-compressor-bypass'
-                id='slider-tuna-compressor-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Compressor')}
-                value={this.state.spec.tuna.Compressor.bypass}
-              />
-            </div>
-            {/* <div className='tuna-convolver'>
-              <h4> Convolver </h4>
-              <Select
-                name='select-reverb-impulse'
-                className='select reverb-impulse'
-                options={[
-                  'BlockInside',
-                  'BottleHall',
-                  'CementBlocks1',
-                  'CementBlocks2',
-                  'ChateaudeLogneOutside',
-                  'ConcLongEchoHall',
-                  'DeepSpace',
-                  'DerlonSanctuary',
-                  'DirectCabinetN1',
-                  'DirectCabinetN2',
-                  'DirectCabinetN3',
-                  'DirectCabinetN4',
-                  'FiveColumns',
-                  'FiveColunsLong',
-                  'French18thCenturySalon',
-                  'GoingHome',
-                  'Greek7EchoHall',
-                  'HighlyDampedLargeRoom',
-                  'InTheSilo',
-                  'InTheSiloRevised',
-                  'LargeBottleHall',
-                  'LargeLongEchoHall',
-                  'LargeWideEchoHall',
-                  'MasonicLodge',
-                  'Musikvereinsaal',
-                  'NarrowBumpySpace',
-                  'NiceDrumRoom',
-                  'OnaStar',
-                  'ParkingGarage',
-                  'Rays',
-                  'RightGlassTable',
-                  'RubyRoom',
-                  'ScalaMilanOperaHall',
-                  'SmallPrehistoricCave',
-                  'StNicolaesChurch',
-                  'TrigRoom',
-                  'VocalDuo',
-                ]}
-                updateSelection={this.updateTunaConvolverImpulse(e)}
-              />
-              <Slider
-                label='highCut'
-                className='slider tuna-convolver-highCut'
-                id='slider-tuna-convolver-highCut'
-                min={20}
-                max={22050}
-                step={1}
-                handleChange={this.updateTuna('Convolver', 'highCut')}
-                value={this.state.spec.tuna.Convolver.highCut}
-              />
-              <Slider
-                label='lowCut'
-                className='slider tuna-convolver-low-cut'
-                id='slider-tuna-convolver-low-cut'
-                min={20}
-                max={22050}
-                step={1}
-                handleChange={this.updateTuna('Convolver', 'lowCut')}
-                value={this.state.spec.tuna.Convolver.lowCut}
-              />
-              <Slider
-                label='dryLevel'
-                className='slider tuna-convolver-dry-level'
-                id='slider-tuna-convolver-dry-level'
-                min={0}
-                max={2}
-                step={0.01}
-                handleChange={this.updateTuna('Convolver', 'dryLevel')}
-                value={this.state.spec.tuna.Convolver.dryLevel}
-              />
-              <Slider
-                label='wetLevel'
-                className='slider tuna-convolver-wet-level'
-                id='slider-tuna-convolver-wet-level'
-                min={0}
-                max={2}
-                step={0.01}
-                handleChange={this.updateTuna('Convolver', 'wetLevel')}
-                value={this.state.spec.tuna.Convolver.wetLevel}
-              />
-              <Slider
-                label='level'
-                className='slider tuna-convolver-level'
-                id='slider-tuna-convolver-level'
-                min={0}
-                max={2}
-                step={0.01}
-                handleChange={this.updateTuna('Convolver', 'level')}
-                value={this.state.spec.tuna.Convolver.level}
-              />
-              <Slider
-                label='Bypass'
-                className='slider tuna-convolver-bypass'
-                id='slider-tuna-convolver-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Convolver')}
-                value={this.state.spec.tuna.Convolver.bypass}
-              />
-            </div>
-            <div className='tuna-filter'>
-              <h4> Filter </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-filter-bypass'
-                id='slider-tuna-filter-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Filter')}
-                value={this.state.spec.tuna.Filter.bypass}
-              />
-            </div>
-            <div classNme='tuna-cabinet'>
-              <h4> Cabinet </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-cabinet-bypass'
-                id='slider-tuna-cabinet-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Cabinet')}
-                value={this.state.spec.tuna.Cabinet.bypass}
-              />
-            </div>
-            */}
-            <div className='tuna-tremolo'>
-              <h4> Tremolo </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-tremolo-bypass'
-                id='slider-tuna-tremolo-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Tremolo')}
-                value={this.state.spec.tuna.Tremolo.bypass}
-              />
-            </div>
-            <div className='tuna-wahah'>
-              <h4> WahWah </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-wahwah-bypass'
-                id='slider-tuna-wahwah-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('WahWah')}
-                value={this.state.spec.tuna.WahWah.bypass}
-              />
-            </div>
-            <div className='tuna-bitcrusher'>
-              <h4> Bitcrusher </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-bitcrusher-bypass'
-                id='slider-tuna-bitcrusher-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('Bitcrusher')}
-                value={this.state.spec.tuna.Bitcrusher.bypass}
-              />
-            </div>
-            <div className='tuna-moog-filter'>
-              <h4> Moog Filter </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-moog-filter-bypass'
-                id='slider-tuna-moog-filter-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('MoogFilter')}
-                value={this.state.spec.tuna.MoogFilter.bypass}
-              />
-            </div>
-            <div className='tuna-ping-pong-delay'>
-              <h4> PingPong Delay </h4>
-              <Slider
-                label='Bypass'
-                className='slider tuna-ping-pong-delay-bypass'
-                id='slider-tuna-ping-pong-delay-bypass'
-                min={0}
-                max={1}
-                step={1}
-                handleChange={this.updateTunaBypass('PingPongDelay')}
-                value={this.state.spec.tuna.PingPongDelay.bypass}
-              />
-            </div>
           </div>
+        </div>
       </div>
     )
   }

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -174,7 +174,6 @@ export class SoundMaker extends Component {
   }
 
   updateValue = (key) => ({ target }) => {
-    console.log(key)
     this.setState(update(this.state, { spec: { [key]: { $set: parseFloat(target.value) } } }))
   }
 
@@ -188,7 +187,6 @@ export class SoundMaker extends Component {
   }
 
   updateADSR = (key) => ({ target }) => {
-    console.log(key)
     this.setState(update(this.state, { spec: { env: { [key]: { $set: this.round(target.value, 4) } } } }))
   }
 
@@ -198,7 +196,6 @@ export class SoundMaker extends Component {
   }
 
   updateFilterEnvelope = (key) => ({ target }) => {
-    console.log(key)
     this.setState(update(this.state, { spec: { filter: { env: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
@@ -212,32 +209,12 @@ export class SoundMaker extends Component {
     this.setState(update(this.state, { spec: { reverb: { impulse: { $set: newReverbImpulseURL } } } }))
   }
 
-  // updateDelay = (key) => ({ target }) => {
-  //   this.setState(update(this.state, { spec: { delay: { [key]: { $set: this.round(target.value, 4) } } } }))
-  // }
-
   updateShape = (key) => ({ target }) => {
     this.setState(update(this.state, { spec: { [key]: { shape: { $set: target.value } } } }))
   }
 
-  // updateTemoloShape(e) {
-  //   this.setState(update(this.state, { spec: { tremolo: { shape: { $set: e.target.value } } } }))
-  // }
-
-  // updateTremolo = (key) => ({ target }) => {
-  //   this.setState(update(this.state, { spec: { tremolo: { [key]: { $set: this.round(target.value, 4) } } } }))
-  // }
-
   updateVibrato = (key) => ({ target }) => {
     this.setState(update(this.state, { spec: { vibrato: { [key]: { $set: this.round(target.value, 4) } } } }))
-  }
-
-  updateTunaChorus = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { Chorus: { [key]: { $set: this.round(target.value, 4) } } } } }))
-  }
-
-  updateTunaOverdrive = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { Overdrive: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
   updateTunaBypass = (key) => ({ target }) => {
@@ -247,30 +224,6 @@ export class SoundMaker extends Component {
   updateTuna = (effect, property) => ({ target }) => {
     this.setState(update(this.state, { spec: { tuna: { [effect]: { [property]: { $set: this.round(target.value, 4) } } } } }))
   }
-
-  updateTunaPhaser = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { Phaser: { [key]: { $set: this.round(target.value, 4) } } } } }))
-  }
-
-  updateTunaCompressor = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { Compressor: { [key]: { $set: this.round(target.value, 4) } } } } }))
-  }
-
-  updateTunaCompressor = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { Compressor: { [key]: { $set: this.round(target.value, 4) } } } } }))
-  }
-
-  // updateTunaConvolver = (key) => ({ target }) => {
-  //   this.setState(update(this.state, { spec: { tuna: { Convolver: { [key]: { $set: this.round(target.value, 4) } } } } }))
-  // }
-
-  // updateTunaConvolverImpulse(e) {
-  //   const newReverbImpulseURL = `http://localhost:3000/api/v1/impulses?id=${e.target.value}.wav`
-  //   this.setState(update(this.state, { spec: { tuna: { Convolver: { impulse: { $set: newReverbImpulseURL } } } } }))
-  // }
-
-
-
 
   render() {
     return (

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -244,12 +244,16 @@ export class SoundMaker extends Component {
     this.setState(update(this.state, { spec: { tuna: { [key]: { bypass: { $set: parseInt(target.value, 10) } } } } }))
   }
 
-  updateTunaDelay = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tuna: { Delay: { [key]: { $set: this.round(target.value, 4) } } } } }))
+  updateTuna = (effect, property) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { [effect]: { [property]: { $set: this.round(target.value, 4) } } } } }))
   }
 
   updateTunaPhaser = (key) => ({ target }) => {
     this.setState(update(this.state, { spec: { tuna: { Phaser: { [key]: { $set: this.round(target.value, 4) } } } } }))
+  }
+
+  updateTunaCompressor = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { Compressor: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
   updateTunaCompressor = (key) => ({ target }) => {
@@ -603,7 +607,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={8}
                 step={0.1}
-                handleChange={this.updateTunaChorus('rate')}
+                handleChange={this.updateTuna('Chorus', 'rate')}
                 value={this.state.spec.tuna.Chorus.rate}
               />
               <Slider
@@ -613,7 +617,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={this.updateTunaChorus('feedback')}
+                handleChange={this.updateTuna('Chorus', 'feedback')}
                 value={this.state.spec.tuna.Chorus.feedback}
               />
               <Slider
@@ -623,7 +627,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={this.updateTunaChorus('delay')}
+                handleChange={this.updateTuna('Chorus', 'delay')}
                 value={this.state.spec.tuna.Chorus.delay}
               />
               <Slider
@@ -646,7 +650,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.10}
-                handleChange={this.updateTunaDelay('feedback')}
+                handleChange={this.updateTuna('Delay', 'feedback')}
                 value={this.state.spec.tuna.Delay.feedback}
               />
               <Slider
@@ -656,7 +660,7 @@ export class SoundMaker extends Component {
                 min={1}
                 max={10000}
                 step={1}
-                handleChange={this.updateTunaDelay('delayTime')}
+                handleChange={this.updateTuna('Delay', 'delayTime')}
                 value={this.state.spec.tuna.Delay.delayTime}
               />
               <Slider
@@ -666,7 +670,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.10}
-                handleChange={this.updateTunaDelay('wetLevel')}
+                handleChange={this.updateTuna('Delay', 'wetLevel')}
                 value={this.state.spec.tuna.Delay.wetLevel}
               />
               <Slider
@@ -676,7 +680,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.10}
-                handleChange={this.updateTunaDelay('dryLevel')}
+                handleChange={this.updateTuna('Delay', 'dryLevel')}
                 value={this.state.spec.tuna.Delay.dryLevel}
               />
               <Slider
@@ -686,7 +690,7 @@ export class SoundMaker extends Component {
                 min={20}
                 max={22050}
                 step={1}
-                handleChange={this.updateTunaDelay('cutoff')}
+                handleChange={this.updateTuna('Delay', 'cutoff')}
                 value={this.state.spec.tuna.Delay.cutoff}
               />
               <Slider
@@ -709,7 +713,7 @@ export class SoundMaker extends Component {
                 min={0.1}
                 max={8}
                 step={0.1}
-                handleChange={this.updateTunaPhaser('rate')}
+                handleChange={this.updateTuna('Phaser', 'rate')}
                 value={this.state.spec.tuna.Phaser.rate}
               />
               <Slider
@@ -719,7 +723,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.1}
-                handleChange={this.updateTunaPhaser('depth')}
+                handleChange={this.updateTuna('Phaser', 'depth')}
                 value={this.state.spec.tuna.Phaser.depth}
               />
               <Slider
@@ -729,7 +733,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={this.updateTunaPhaser('feedback')}
+                handleChange={this.updateTuna('Phaser', 'feedback')}
                 value={this.state.spec.tuna.Phaser.feedback}
               />
               <Slider
@@ -739,7 +743,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={180}
                 step={1}
-                handleChange={this.updateTunaPhaser('stereoPhase')}
+                handleChange={this.updateTuna('Phaser', 'stereoPhase')}
                 value={this.state.spec.tuna.Phaser.stereoPhase}
               />
               <Slider
@@ -749,7 +753,7 @@ export class SoundMaker extends Component {
                 min={500}
                 max={1500}
                 step={1}
-                handleChange={this.updateTunaPhaser('baseModulationFrequency')}
+                handleChange={this.updateTuna('Phaser', 'baseModulationFrequency')}
                 value={this.state.spec.tuna.Phaser.baseModulationFrequency}
               />
               <Slider
@@ -772,7 +776,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={this.updateTunaOverdrive('outputGain')}
+                handleChange={this.updateTuna('Overdrive', 'outputGain')}
                 value={this.state.spec.tuna.Overdrive.outputGain}
               />
               <Slider
@@ -782,7 +786,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={this.updateTunaOverdrive('drive')}
+                handleChange={this.updateTuna('Overdrive', 'drive')}
                 value={this.state.spec.tuna.Overdrive.drive}
               />
               <Slider
@@ -792,7 +796,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={this.updateTunaOverdrive('curveAmount')}
+                handleChange={this.updateTuna('Overdrive', 'curveAmount')}
                 value={this.state.spec.tuna.Overdrive.curveAmount}
               />
               <Slider
@@ -802,7 +806,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={5}
                 step={1}
-                handleChange={this.updateTunaOverdrive('algorithmIndex')}
+                handleChange={this.updateTuna('Overdrive', 'algorithmIndex')}
                 value={this.state.spec.tuna.Overdrive.algorithmIndex}
               />
               <Slider
@@ -825,7 +829,7 @@ export class SoundMaker extends Component {
                 min={-100}
                 max={0}
                 step={1}
-                handleChange={this.updateTunaCompressor('threshold')}
+                handleChange={this.updateTuna('Compressor', 'threshold')}
                 value={this.state.spec.tuna.Compressor.threshold}
               />
               <Slider
@@ -835,7 +839,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={10}
                 step={1}
-                handleChange={this.updateTunaCompressor('makeupGain')}
+                handleChange={this.updateTuna('Compressor', 'makeupGain')}
                 value={this.state.spec.tuna.Compressor.makeupGain}
               />
               <Slider
@@ -845,7 +849,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1000}
                 step={1}
-                handleChange={this.updateTunaCompressor('attack')}
+                handleChange={this.updateTuna('Compressor', 'attack')}
                 value={this.state.spec.tuna.Compressor.attack}
               />
               <Slider
@@ -855,7 +859,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={10}
                 step={1}
-                handleChange={this.updateTunaCompressor('release')}
+                handleChange={this.updateTuna('Compressor', 'release')}
                 value={this.state.spec.tuna.Compressor.release}
               />
               <Slider
@@ -865,7 +869,7 @@ export class SoundMaker extends Component {
                 min={1}
                 max={20}
                 step={1}
-                handleChange={this.updateTunaCompressor('ratio')}
+                handleChange={this.updateTuna('Compressor', 'ratio')}
                 value={this.state.spec.tuna.Compressor.ratio}
               />
               <Slider
@@ -875,7 +879,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={40}
                 step={1}
-                handleChange={this.updateTunaCompressor('knee')}
+                handleChange={this.updateTuna('Compressor', 'knee')}
                 value={this.state.spec.tuna.Compressor.knee}
               />
               <Slider
@@ -885,7 +889,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={this.updateTunaCompressor('automakeup')}
+                handleChange={this.updateTuna('Compressor', 'automakeup')}
                 value={this.state.spec.tuna.Compressor.automakeup}
               />
               <Slider
@@ -952,7 +956,7 @@ export class SoundMaker extends Component {
                 min={20}
                 max={22050}
                 step={1}
-                handleChange={this.updateTunaConvolver('highCut')}
+                handleChange={this.updateTuna('Convolver', 'highCut')}
                 value={this.state.spec.tuna.Convolver.highCut}
               />
               <Slider
@@ -962,7 +966,7 @@ export class SoundMaker extends Component {
                 min={20}
                 max={22050}
                 step={1}
-                handleChange={this.updateTunaConvolver('lowCut')}
+                handleChange={this.updateTuna('Convolver', 'lowCut')}
                 value={this.state.spec.tuna.Convolver.lowCut}
               />
               <Slider
@@ -972,7 +976,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={2}
                 step={0.01}
-                handleChange={this.updateTunaConvolver('dryLevel')}
+                handleChange={this.updateTuna('Convolver', 'dryLevel')}
                 value={this.state.spec.tuna.Convolver.dryLevel}
               />
               <Slider
@@ -982,7 +986,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={2}
                 step={0.01}
-                handleChange={this.updateTunaConvolver('wetLevel')}
+                handleChange={this.updateTuna('Convolver', 'wetLevel')}
                 value={this.state.spec.tuna.Convolver.wetLevel}
               />
               <Slider
@@ -992,7 +996,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={2}
                 step={0.01}
-                handleChange={this.updateTunaConvolver('level')}
+                handleChange={this.updateTuna('Convolver', 'level')}
                 value={this.state.spec.tuna.Convolver.level}
               />
               <Slider

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -1,11 +1,9 @@
 import React, { Component } from 'react'
-import { Link, browserHistory } from 'react-router'
+import { Prompt } from 'react-router-dom'
 import Select from './Select'
 import Slider from './Slider'
 import update from 'immutability-helper'
 import Button from '../Button'
-// import Toggle from 'react-toggle'
-
 
 export class SoundMaker extends Component {
   constructor() {
@@ -60,12 +58,11 @@ export class SoundMaker extends Component {
     }
   }
 
-  componentWillUnmount() {
-    if(this.state.savedchanges === false){
-      prompt('you have unsaved changes')
-      browserHistory('/newsound')
-    }
-  }
+  // componentWillUnmount() {
+  //   if (this.state.savedchanges === false) {
+  //     prompt('')
+  //   }
+  // }
 
   round(number, decimals) {
     return +(Math.round(number + 'e+' + decimals) + 'e-' + decimals)
@@ -90,60 +87,64 @@ export class SoundMaker extends Component {
   }
 
   updateValue = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { [key]: { $set: parseFloat(target.value) } } }))
+    this.setState(update(this.state, { spec: { [key]: { $set: parseFloat(target.value) } } }), () => this.setState({ savedchanges: false }))
   }
 
   updatePitch = ({ target }) => {
     const newPitch = target.value.toUpperCase()
-    this.setState(update(this.state, { spec: { pitch: { $set: newPitch } } }))
+    this.setState(update(this.state, { spec: { pitch: { $set: newPitch } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateSource = ({ target }) => {
-    this.setState(update(this.state, { spec: { source: { $set: target.value } } }))
+    this.setState(update(this.state, { spec: { source: { $set: target.value } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateADSR = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { env: { [key]: { $set: this.round(target.value, 4) } } } }))
+    this.setState(update(this.state, { spec: { env: { [key]: { $set: this.round(target.value, 4) } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateFilter = (key) => ({ target }) => {
     const newValue = key === 'type' ? target.value : this.round(target.value, 4)
-    this.setState(update(this.state, { spec: { filter: { [key]: { $set: newValue } } } }))
+    this.setState(update(this.state, { spec: { filter: { [key]: { $set: newValue } } } })), () => this.setState({ savedchanges: false })
   }
 
   updateFilterEnvelope = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { filter: { env: { [key]: { $set: this.round(target.value, 4) } } } } }))
+    this.setState(update(this.state, { spec: { filter: { env: { [key]: { $set: this.round(target.value, 4) } } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateReverbWet = ({ target }) => {
     const newReverbWet = this.round(target.value, 4)
-    this.setState(update(this.state, { spec: { reverb: { wet: { $set: newReverbWet } } } }))
+    this.setState(update(this.state, { spec: { reverb: { wet: { $set: newReverbWet } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateReverbImpulse = ({ target }) => {
     const newReverbImpulseURL = `http://localhost:3000/api/v1/impulses?id=${target.value}.wav`
-    this.setState(update(this.state, { spec: { reverb: { impulse: { $set: newReverbImpulseURL } } } }))
+    this.setState(update(this.state, { spec: { reverb: { impulse: { $set: newReverbImpulseURL } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateShape = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { [key]: { shape: { $set: target.value } } } }))
+    this.setState(update(this.state, { spec: { [key]: { shape: { $set: target.value } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateVibrato = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { vibrato: { [key]: { $set: this.round(target.value, 4) } } } }))
+    this.setState(update(this.state, { spec: { vibrato: { [key]: { $set: this.round(target.value, 4) } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateDelay = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { delay: { [key]: { $set: this.round(target.value, 4) } } } }))
+    this.setState(update(this.state, { spec: { delay: { [key]: { $set: this.round(target.value, 4) } } } }), () => this.setState({ savedchanges: false }))
   }
 
   updateTremolo = (key) => ({ target }) => {
-    this.setState(update(this.state, { spec: { tremolo: { [key]: { $set: this.round(target.value, 4) } } } }))
+    this.setState(update(this.state, { spec: { tremolo: { [key]: { $set: this.round(target.value, 4) } } } }), () => this.setState({ savedchanges: false }))
   }
 
   render() {
     return (
       <div>
+        <Prompt
+          when={!this.state.savedchanges}
+          message='You have unsaved changes that will be lost. Are you sure want to leave?'
+        />
         <div className='btn-group'>
           {!this.state.savedchanges && <p>You have unsaved changes.</p>}
           <Button text='Play' handleClick={this.previewSound} />

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -79,7 +79,7 @@ export class SoundMaker extends Component {
             bypass: 1,
           },
           Phaser: {
-            rate: 1.2,                     // 0.01 to 8 is a decent range, but higher values are possible
+            rate: 1.2,                     // 0.01 to 8 is a decent rangbut higher values are possible
             depth: 0.3,                    // 0 to 1
             feedback: 0.2,                 // 0 to 1+
             stereoPhase: 30,               // 0 to 180
@@ -173,103 +173,97 @@ export class SoundMaker extends Component {
     this.props.stopAllSounds()
   }
 
-  updateVolume = ({ target }) => {
-    this.setState(update(this.state, { spec: { volume: { $set: parseFloat(target.value) } } }))
+  updateValue = (key) => ({ target }) => {
+    console.log(key)
+    this.setState(update(this.state, { spec: { [key]: { $set: parseFloat(target.value) } } }))
   }
 
-  updatePanning = ({ target }) => {
-    this.setState(update(this.state, { spec: { panning: { $set: parseFloat(target.value) } } }))
-  }
-
-  updateDetune = ({ target }) => {
-    this.setState(update(this.state, { spec: { detune: { $set: parseFloat(target.value) } } }))
-  }
-
-  updatePitch = (e) => {
-    const newPitch = e.target.value.toUpperCase()
+  updatePitch = ({ target }) => {
+    const newPitch = target.value.toUpperCase()
     this.setState(update(this.state, { spec: { pitch: { $set: newPitch } } }))
   }
 
-  updateSource(e) {
-    this.setState(update(this.state, { spec: { source: { $set: e.target.value } } }))
+  updateSource = ({ target }) => {
+    this.setState(update(this.state, { spec: { source: { $set: target.value } } }))
   }
 
-  updateADSR(e, key) {
-    this.setState(update(this.state, { spec: { env: { [key]: { $set: this.round(e.target.value, 4) } } } }))
+  updateADSR = (key) => ({ target }) => {
+    console.log(key)
+    this.setState(update(this.state, { spec: { env: { [key]: { $set: this.round(target.value, 4) } } } }))
   }
 
-  updateFilter(e, key) {
-    const newValue = key === 'type' ? e.target.value : this.round(e.target.value, 4)
+  updateFilter = (key) => ({ target }) => {
+    const newValue = key === 'type' ? target.value : this.round(target.value, 4)
     this.setState(update(this.state, { spec: { filter: { [key]: { $set: newValue } } } }))
   }
 
-  updateFilterEnvelope(e, key) {
+  updateFilterEnvelope = (key) => ({ target }) => {
     console.log(key)
-    this.setState(update(this.state, { spec: { filter: { env: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
+    this.setState(update(this.state, { spec: { filter: { env: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
-  updateReverbWet(e) {
-    const newReverbWet = this.round(e.target.value, 4)
+  updateReverbWet = ({ target }) => {
+    const newReverbWet = this.round(target.value, 4)
     this.setState(update(this.state, { spec: { reverb: { wet: { $set: newReverbWet } } } }))
   }
 
-  updateReverbImpulse(e) {
-    const newReverbImpulseURL = `http://localhost:3000/api/v1/impulses?id=${e.target.value}.wav`
+  updateReverbImpulse = ({ target }) => {
+    const newReverbImpulseURL = `http://localhost:3000/api/v1/impulses?id=${target.value}.wav`
     this.setState(update(this.state, { spec: { reverb: { impulse: { $set: newReverbImpulseURL } } } }))
   }
 
-  updateDelay(e, key) {
-    this.setState(update(this.state, { spec: { delay: { [key]: { $set: this.round(e.target.value, 4) } } } }))
+  // updateDelay = (key) => ({ target }) => {
+  //   this.setState(update(this.state, { spec: { delay: { [key]: { $set: this.round(target.value, 4) } } } }))
+  // }
+
+  updateShape = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { [key]: { shape: { $set: target.value } } } }))
   }
 
-  updateShape(e, key) {
-    this.setState(update(this.state, { spec: { [key]: { shape: { $set: e.target.value } } } }))
+  // updateTemoloShape(e) {
+  //   this.setState(update(this.state, { spec: { tremolo: { shape: { $set: e.target.value } } } }))
+  // }
+
+  // updateTremolo = (key) => ({ target }) => {
+  //   this.setState(update(this.state, { spec: { tremolo: { [key]: { $set: this.round(target.value, 4) } } } }))
+  // }
+
+  updateVibrato = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { vibrato: { [key]: { $set: this.round(target.value, 4) } } } }))
   }
 
-  updateTemoloShape(e) {
-    this.setState(update(this.state, { spec: { tremolo: { shape: { $set: e.target.value } } } }))
+  updateTunaChorus = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { Chorus: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
-  updateTremolo(e, key) {
-    this.setState(update(this.state, { spec: { tremolo: { [key]: { $set: this.round(e.target.value, 4) } } } }))
+  updateTunaOverdrive = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { Overdrive: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
-  updateVibrato(e, key) {
-    this.setState(update(this.state, { spec: { vibrato: { [key]: { $set: this.round(e.target.value, 4) } } } }))
+  updateTunaBypass = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { [key]: { bypass: { $set: parseInt(target.value, 10) } } } } }))
   }
 
-  updateTunaChorus(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { Chorus: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
+  updateTunaDelay = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { Delay: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
-  updateTunaOverdrive(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { Overdrive: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
+  updateTunaPhaser = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { Phaser: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
-  updateTunaBypass(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { [key]: { bypass: { $set: parseInt(e.target.value, 10) } } } } }))
+  updateTunaCompressor = (key) => ({ target }) => {
+    this.setState(update(this.state, { spec: { tuna: { Compressor: { [key]: { $set: this.round(target.value, 4) } } } } }))
   }
 
-  updateTunaDelay(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { Delay: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
-  }
+  // updateTunaConvolver = (key) => ({ target }) => {
+  //   this.setState(update(this.state, { spec: { tuna: { Convolver: { [key]: { $set: this.round(target.value, 4) } } } } }))
+  // }
 
-  updateTunaPhaser(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { Phaser: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
-  }
-
-  updateTunaCompressor(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { Compressor: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
-  }
-
-  updateTunaConvolver(e, key) {
-    this.setState(update(this.state, { spec: { tuna: { Convolver: { [key]: { $set: this.round(e.target.value, 4) } } } } }))
-  }
-
-  updateTunaConvolverImpulse(e) {
-    const newReverbImpulseURL = `http://localhost:3000/api/v1/impulses?id=${e.target.value}.wav`
-    this.setState(update(this.state, { spec: { tuna: { Convolver: { impulse: { $set: newReverbImpulseURL } } } } }))
-  }
+  // updateTunaConvolverImpulse(e) {
+  //   const newReverbImpulseURL = `http://localhost:3000/api/v1/impulses?id=${e.target.value}.wav`
+  //   this.setState(update(this.state, { spec: { tuna: { Convolver: { impulse: { $set: newReverbImpulseURL } } } } }))
+  // }
 
 
 
@@ -297,7 +291,7 @@ export class SoundMaker extends Component {
             min={0}
             max={1}
             step={0.1}
-            handleChange={this.updateVolume}
+            handleChange={this.updateValue('volume')}
             value={this.state.spec.volume}
           />
           <Slider
@@ -307,7 +301,7 @@ export class SoundMaker extends Component {
             min={0}
             max={1200}
             step={1}
-            handleChange={this.updateDetune}
+            handleChange={this.updateValue('detune')}
             value={this.state.spec.detune}
           />
           <Slider
@@ -317,7 +311,7 @@ export class SoundMaker extends Component {
             min={-1}
             max={1}
             step={0.01}
-            handleChange={this.updatePanning}
+            handleChange={this.updateValue('panning')}
             value={this.state.spec.panning}
           />
           <span> Pitch (A0-C8) </span>
@@ -334,7 +328,7 @@ export class SoundMaker extends Component {
             min={0}
             max={1}
             step={0.01}
-            handleChange={(e) => this.updateADSR(e, 'attack')}
+            handleChange={this.updateADSR('attack')}
             value={this.state.spec.env.attack}
           />
           <Slider
@@ -344,7 +338,7 @@ export class SoundMaker extends Component {
             min={0}
             max={5}
             step={0.01}
-            handleChange={(e) => this.updateADSR(e, 'decay')}
+            handleChange={this.updateADSR('decay')}
             value={this.state.spec.env.decay}
           />
           <Slider
@@ -354,7 +348,7 @@ export class SoundMaker extends Component {
             min={0}
             max={1}
             step={0.01}
-            handleChange={(e) => this.updateADSR(e, 'sustain')}
+            handleChange={this.updateADSR('sustain')}
             value={this.state.spec.env.sustain}
           />
           <Slider
@@ -364,7 +358,7 @@ export class SoundMaker extends Component {
             min={0}
             max={10}
             step={0.01}
-            handleChange={(e) => this.updateADSR(e, 'hold')}
+            handleChange={this.updateADSR('hold')}
             value={this.state.spec.env.hold}
           />
           <Slider
@@ -374,7 +368,7 @@ export class SoundMaker extends Component {
             min={0}
             max={10}
             step={0.01}
-            handleChange={(e) => this.updateADSR(e, 'release')}
+            handleChange={this.updateADSR('release')}
             value={this.state.spec.env.release}
           />
         </div>
@@ -384,7 +378,7 @@ export class SoundMaker extends Component {
             name='filter-type'
             className='select filter-type'
             options={['allpass', 'lowpass', 'highpass', 'bandpass', 'lowshelf', 'peaking', 'notch']}
-            updateSelection={e => this.updateFilter(e, 'type')}
+            updateSelection={this.updateFilter('type')}
           />
           <Slider
             label='Frequency'
@@ -393,7 +387,7 @@ export class SoundMaker extends Component {
             min={0}
             max={5000}
             step={1}
-            handleChange={(e) => this.updateFilter(e, 'frequency')}
+            handleChange={this.updateFilter('frequency')}
             value={this.state.spec.filter.frequency}
           />
           <Slider
@@ -403,7 +397,7 @@ export class SoundMaker extends Component {
             min={0}
             max={10}
             step={0.01}
-            handleChange={(e) => this.updateFilter(e, 'q')}
+            handleChange={this.updateFilter('q')}
             value={this.state.spec.filter.q}
           />
           <Slider
@@ -413,7 +407,7 @@ export class SoundMaker extends Component {
             min={0}
             max={5000}
             step={1}
-            handleChange={(e) => this.updateFilterEnvelope(e, 'frequency')}
+            handleChange={this.updateFilterEnvelope('frequency')}
             value={this.state.spec.filter.env.frequency}
           />
           <Slider
@@ -423,7 +417,7 @@ export class SoundMaker extends Component {
             min={0}
             max={10}
             step={0.01}
-            handleChange={(e) => this.updateFilterEnvelope(e, 'attack')}
+            handleChange={this.updateFilterEnvelope('attack')}
             value={this.state.spec.filter.env.attack}
           />
         </div>
@@ -471,7 +465,7 @@ export class SoundMaker extends Component {
               'TrigRoom',
               'VocalDuo',
             ]}
-            updateSelection={e => this.updateReverbImpulse(e)}
+            updateSelection={this.updateReverbImpulse}
           />
           <Slider
             label='Reverb Wet'
@@ -480,7 +474,7 @@ export class SoundMaker extends Component {
             min={0}
             max={1}
             step={0.01}
-            handleChange={(e) => this.updateReverbWet(e)}
+            handleChange={this.updateReverbWet}
             value={this.state.spec.reverb.wet}
           />
         </div>
@@ -495,7 +489,7 @@ export class SoundMaker extends Component {
               min={0}
               max={2}
               step={0.01}
-              handleChange={(e) => this.updateDelay(e, 'delayTime')}
+              handleChange={updateDelay('delayTime')}
               value={this.state.spec.delay.delayTime}
             />
             <Slider
@@ -505,7 +499,7 @@ export class SoundMaker extends Component {
               min={0}
               max={1}
               step={0.01}
-              handleChange={(e) => this.updateDelay(e, 'wet')}
+              handleChange={updateDelay('wet')}
               value={this.state.spec.delay.wet}
             />
             <Slider
@@ -515,7 +509,7 @@ export class SoundMaker extends Component {
               min={0}
               max={1}
               step={0.01}
-              handleChange={(e) => this.updateDelay(e, 'feedback')}
+              handleChange={updateDelay('feedback')}
               value={this.state.spec.delay.feedback}
             />
           </div> */}
@@ -525,7 +519,7 @@ export class SoundMaker extends Component {
               name='vibrato-shape'
               className='select vibrato-shape'
               options={['sine', 'sawtooth', 'square', 'triangle']}
-              updateSelection={e => this.updateShape(e, 'vibrato')}
+              updateSelection={this.updateShape('vibrato')}
             />
             <Slider
               label='Vibrato Magnitude'
@@ -534,7 +528,7 @@ export class SoundMaker extends Component {
               min={1}
               max={10}
               step={0.1}
-              handleChange={(e) => this.updateVibrato(e, 'magnitude')}
+              handleChange={this.updateVibrato('magnitude')}
               value={this.state.spec.vibrato.magnitude}
             />
             <Slider
@@ -544,7 +538,7 @@ export class SoundMaker extends Component {
               min={0}
               max={10}
               step={0.1}
-              handleChange={(e) => this.updateVibrato(e, 'speed')}
+              handleChange={this.updateVibrato('speed')}
               value={this.state.spec.vibrato.speed}
             />
             <Slider
@@ -554,7 +548,7 @@ export class SoundMaker extends Component {
               min={0}
               max={10}
               step={0.1}
-              handleChange={(e) => this.updateVibrato(e, 'attack')}
+              handleChange={this.updateVibrato('attack')}
               value={this.state.spec.vibrato.attack}
             />
           </div>
@@ -564,7 +558,7 @@ export class SoundMaker extends Component {
               name='tremolo-shape'
               className='select tremolo-shape'
               options={['sine', 'sawtooth', 'square', 'triangle']}
-              updateSelection={e => this.updateTremoloShape(e)}
+              updateSelection={this.updateShape('tremolo')}
             />
             <Slider
               label='Tremolo Magnitude'
@@ -573,7 +567,7 @@ export class SoundMaker extends Component {
               min={1}
               max={10}
               step={0.1}
-              handleChange={(e) => this.updateTremolo(e, 'magnitude')}
+              handleChange={this.updateTremolo('magnitude')}
               value={this.state.spec.tremolo.magnitude}
             />
             <Slider
@@ -583,7 +577,7 @@ export class SoundMaker extends Component {
               min={0}
               max={10}
               step={0.1}
-              handleChange={(e) => this.updateTremolo(e, 'speed')}
+              handleChange={this.updateTremolo('speed')}
               value={this.state.spec.tremolo.speed}
             />
             <Slider
@@ -593,7 +587,7 @@ export class SoundMaker extends Component {
               min={0}
               max={10}
               step={0.1}
-              handleChange={(e) => this.updateTremolo(e, 'attack')}
+              handleChange={this.updateTremolo('attack')}
               value={this.state.spec.tremolo.attack}
             />
           </div>*/}
@@ -609,7 +603,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={8}
                 step={0.1}
-                handleChange={(e) => this.updateTunaChorus(e, 'rate')}
+                handleChange={this.updateTunaChorus('rate')}
                 value={this.state.spec.tuna.Chorus.rate}
               />
               <Slider
@@ -619,7 +613,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={(e) => this.updateTunaChorus(e, 'feedback')}
+                handleChange={this.updateTunaChorus('feedback')}
                 value={this.state.spec.tuna.Chorus.feedback}
               />
               <Slider
@@ -629,7 +623,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={(e) => this.updateTunaChorus(e, 'delay')}
+                handleChange={this.updateTunaChorus('delay')}
                 value={this.state.spec.tuna.Chorus.delay}
               />
               <Slider
@@ -639,7 +633,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Chorus')}
+                handleChange={this.updateTunaBypass('Chorus')}
                 value={this.state.spec.tuna.Chorus.bypass}
               />
             </div>
@@ -652,7 +646,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.10}
-                handleChange={(e) => this.updateTunaDelay(e, 'feedback')}
+                handleChange={this.updateTunaDelay('feedback')}
                 value={this.state.spec.tuna.Delay.feedback}
               />
               <Slider
@@ -662,7 +656,7 @@ export class SoundMaker extends Component {
                 min={1}
                 max={10000}
                 step={1}
-                handleChange={(e) => this.updateTunaDelay(e, 'delayTime')}
+                handleChange={this.updateTunaDelay('delayTime')}
                 value={this.state.spec.tuna.Delay.delayTime}
               />
               <Slider
@@ -672,7 +666,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.10}
-                handleChange={(e) => this.updateTunaDelay(e, 'wetLevel')}
+                handleChange={this.updateTunaDelay('wetLevel')}
                 value={this.state.spec.tuna.Delay.wetLevel}
               />
               <Slider
@@ -682,7 +676,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.10}
-                handleChange={(e) => this.updateTunaDelay(e, 'dryLevel')}
+                handleChange={this.updateTunaDelay('dryLevel')}
                 value={this.state.spec.tuna.Delay.dryLevel}
               />
               <Slider
@@ -692,7 +686,7 @@ export class SoundMaker extends Component {
                 min={20}
                 max={22050}
                 step={1}
-                handleChange={(e) => this.updateTunaDelay(e, 'cutoff')}
+                handleChange={this.updateTunaDelay('cutoff')}
                 value={this.state.spec.tuna.Delay.cutoff}
               />
               <Slider
@@ -702,7 +696,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Delay')}
+                handleChange={this.updateTunaBypass('Delay')}
                 value={this.state.spec.tuna.Delay.bypass}
               />
             </div>
@@ -715,7 +709,7 @@ export class SoundMaker extends Component {
                 min={0.1}
                 max={8}
                 step={0.1}
-                handleChange={(e) => this.updateTunaPhaser(e, 'rate')}
+                handleChange={this.updateTunaPhaser('rate')}
                 value={this.state.spec.tuna.Phaser.rate}
               />
               <Slider
@@ -725,7 +719,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.1}
-                handleChange={(e) => this.updateTunaPhaser(e, 'depth')}
+                handleChange={this.updateTunaPhaser('depth')}
                 value={this.state.spec.tuna.Phaser.depth}
               />
               <Slider
@@ -735,7 +729,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={(e) => this.updateTunaPhaser(e, 'feedback')}
+                handleChange={this.updateTunaPhaser('feedback')}
                 value={this.state.spec.tuna.Phaser.feedback}
               />
               <Slider
@@ -745,7 +739,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={180}
                 step={1}
-                handleChange={(e) => this.updateTunaPhaser(e, 'stereoPhase')}
+                handleChange={this.updateTunaPhaser('stereoPhase')}
                 value={this.state.spec.tuna.Phaser.stereoPhase}
               />
               <Slider
@@ -755,7 +749,7 @@ export class SoundMaker extends Component {
                 min={500}
                 max={1500}
                 step={1}
-                handleChange={(e) => this.updateTunaPhaser(e, 'baseModulationFrequency')}
+                handleChange={this.updateTunaPhaser('baseModulationFrequency')}
                 value={this.state.spec.tuna.Phaser.baseModulationFrequency}
               />
               <Slider
@@ -765,7 +759,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Phaser')}
+                handleChange={this.updateTunaBypass('Phaser')}
                 value={this.state.spec.tuna.Phaser.bypass}
               />
             </div>
@@ -778,7 +772,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={(e) => this.updateTunaOverdrive(e, 'outputGain')}
+                handleChange={this.updateTunaOverdrive('outputGain')}
                 value={this.state.spec.tuna.Overdrive.outputGain}
               />
               <Slider
@@ -788,7 +782,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={(e) => this.updateTunaOverdrive(e, 'drive')}
+                handleChange={this.updateTunaOverdrive('drive')}
                 value={this.state.spec.tuna.Overdrive.drive}
               />
               <Slider
@@ -798,7 +792,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={0.01}
-                handleChange={(e) => this.updateTunaOverdrive(e, 'curveAmount')}
+                handleChange={this.updateTunaOverdrive('curveAmount')}
                 value={this.state.spec.tuna.Overdrive.curveAmount}
               />
               <Slider
@@ -808,7 +802,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={5}
                 step={1}
-                handleChange={(e) => this.updateTunaOverdrive(e, 'algorithmIndex')}
+                handleChange={this.updateTunaOverdrive('algorithmIndex')}
                 value={this.state.spec.tuna.Overdrive.algorithmIndex}
               />
               <Slider
@@ -818,7 +812,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Overdrive')}
+                handleChange={this.updateTunaBypass('Overdrive')}
                 value={this.state.spec.tuna.Overdrive.bypass}
               />
             </div>
@@ -831,7 +825,7 @@ export class SoundMaker extends Component {
                 min={-100}
                 max={0}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'threshold')}
+                handleChange={this.updateTunaCompressor('threshold')}
                 value={this.state.spec.tuna.Compressor.threshold}
               />
               <Slider
@@ -841,7 +835,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={10}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'makeupGain')}
+                handleChange={this.updateTunaCompressor('makeupGain')}
                 value={this.state.spec.tuna.Compressor.makeupGain}
               />
               <Slider
@@ -851,7 +845,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1000}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'attack')}
+                handleChange={this.updateTunaCompressor('attack')}
                 value={this.state.spec.tuna.Compressor.attack}
               />
               <Slider
@@ -861,7 +855,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={10}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'release')}
+                handleChange={this.updateTunaCompressor('release')}
                 value={this.state.spec.tuna.Compressor.release}
               />
               <Slider
@@ -871,7 +865,7 @@ export class SoundMaker extends Component {
                 min={1}
                 max={20}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'ratio')}
+                handleChange={this.updateTunaCompressor('ratio')}
                 value={this.state.spec.tuna.Compressor.ratio}
               />
               <Slider
@@ -881,7 +875,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={40}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'knee')}
+                handleChange={this.updateTunaCompressor('knee')}
                 value={this.state.spec.tuna.Compressor.knee}
               />
               <Slider
@@ -891,7 +885,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaCompressor(e, 'automakeup')}
+                handleChange={this.updateTunaCompressor('automakeup')}
                 value={this.state.spec.tuna.Compressor.automakeup}
               />
               <Slider
@@ -901,7 +895,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Compressor')}
+                handleChange={this.updateTunaBypass('Compressor')}
                 value={this.state.spec.tuna.Compressor.bypass}
               />
             </div>
@@ -949,7 +943,7 @@ export class SoundMaker extends Component {
                   'TrigRoom',
                   'VocalDuo',
                 ]}
-                updateSelection={e => this.updateTunaConvolverImpulse(e)}
+                updateSelection={this.updateTunaConvolverImpulse(e)}
               />
               <Slider
                 label='highCut'
@@ -958,7 +952,7 @@ export class SoundMaker extends Component {
                 min={20}
                 max={22050}
                 step={1}
-                handleChange={(e) => this.updateTunaConvolver(e, 'highCut')}
+                handleChange={this.updateTunaConvolver('highCut')}
                 value={this.state.spec.tuna.Convolver.highCut}
               />
               <Slider
@@ -968,7 +962,7 @@ export class SoundMaker extends Component {
                 min={20}
                 max={22050}
                 step={1}
-                handleChange={(e) => this.updateTunaConvolver(e, 'lowCut')}
+                handleChange={this.updateTunaConvolver('lowCut')}
                 value={this.state.spec.tuna.Convolver.lowCut}
               />
               <Slider
@@ -978,7 +972,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={2}
                 step={0.01}
-                handleChange={(e) => this.updateTunaConvolver(e, 'dryLevel')}
+                handleChange={this.updateTunaConvolver('dryLevel')}
                 value={this.state.spec.tuna.Convolver.dryLevel}
               />
               <Slider
@@ -988,7 +982,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={2}
                 step={0.01}
-                handleChange={(e) => this.updateTunaConvolver(e, 'wetLevel')}
+                handleChange={this.updateTunaConvolver('wetLevel')}
                 value={this.state.spec.tuna.Convolver.wetLevel}
               />
               <Slider
@@ -998,7 +992,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={2}
                 step={0.01}
-                handleChange={(e) => this.updateTunaConvolver(e, 'level')}
+                handleChange={this.updateTunaConvolver('level')}
                 value={this.state.spec.tuna.Convolver.level}
               />
               <Slider
@@ -1008,7 +1002,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Convolver')}
+                handleChange={this.updateTunaBypass('Convolver')}
                 value={this.state.spec.tuna.Convolver.bypass}
               />
             </div>
@@ -1021,7 +1015,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Filter')}
+                handleChange={this.updateTunaBypass('Filter')}
                 value={this.state.spec.tuna.Filter.bypass}
               />
             </div>
@@ -1034,7 +1028,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Cabinet')}
+                handleChange={this.updateTunaBypass('Cabinet')}
                 value={this.state.spec.tuna.Cabinet.bypass}
               />
             </div>
@@ -1048,7 +1042,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Tremolo')}
+                handleChange={this.updateTunaBypass('Tremolo')}
                 value={this.state.spec.tuna.Tremolo.bypass}
               />
             </div>
@@ -1061,7 +1055,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'WahWah')}
+                handleChange={this.updateTunaBypass('WahWah')}
                 value={this.state.spec.tuna.WahWah.bypass}
               />
             </div>
@@ -1074,7 +1068,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'Bitcrusher')}
+                handleChange={this.updateTunaBypass('Bitcrusher')}
                 value={this.state.spec.tuna.Bitcrusher.bypass}
               />
             </div>
@@ -1087,7 +1081,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'MoogFilter')}
+                handleChange={this.updateTunaBypass('MoogFilter')}
                 value={this.state.spec.tuna.MoogFilter.bypass}
               />
             </div>
@@ -1100,7 +1094,7 @@ export class SoundMaker extends Component {
                 min={0}
                 max={1}
                 step={1}
-                handleChange={(e) => this.updateTunaBypass(e, 'PingPongDelay')}
+                handleChange={this.updateTunaBypass('PingPongDelay')}
                 value={this.state.spec.tuna.PingPongDelay.bypass}
               />
             </div>

--- a/lib/containers/SoundMakerContainer.jsx
+++ b/lib/containers/SoundMakerContainer.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import { previewSound, stopSound, stopAllSounds } from '../actions'
 import SoundMaker from '../components/SoundMaker'

--- a/vendor/wad.js
+++ b/vendor/wad.js
@@ -3,6 +3,7 @@ import Tuna from 'tunajs'
 /** Let's do the vendor-prefix dance. **/
 var audioContext = window.AudioContext || window.webkitAudioContext;
 var context = new audioContext();
+var tuna = new Tuna(context)
 
 // create a wrapper for old versions of `getUserMedia`
 var getUserMedia = (function (window) {
@@ -267,6 +268,7 @@ var Wad = (function () {
 
   var Wad = function (arg) {
     /** Set basic Wad properties **/
+    console.log(context)
     this.source = arg.source;
     this.destination = arg.destination || context.destination; // the last node the sound is routed to
     this.volume = valueOrDefault(arg.volume, 1); // peak volume. min:0, max:1 (actually max is infinite, but ...just keep it at or below 1)
@@ -322,7 +324,8 @@ var Wad = (function () {
   };
   Wad.micConsent = false
   Wad.audioContext = context
-  Wad.tuna = new Tuna(Wad.audioContext)
+  Wad.tuna = tuna
+
 
   /** When a note is played, these two functions will schedule changes in volume and filter frequency,
   as specified by the volume envelope and filter envelope **/


### PR DESCRIPTION
* Remove all Tuna effects from the oscillator (`SoundMaker`) for now (since they were hurting performance).

* Removed some `console.log`s

* Add `Prompt` component from ReactRouter 4 (`react-router-dom`) in `SoundMaker` to prevent transition when unsaved edits have been made to the sound.