### PR TITLE
Edit Sound Functionality

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -32,6 +32,13 @@ export const userError = (error) => {
   }
 }
 
+export const setSelectedSound = (sound) => {
+  return {
+    type: 'SELECTED_SOUND',
+    sound,
+  }
+}
+
 export const stopSound = () => (dispatch, getState) => {
   const { sounds } = getState()
 
@@ -82,7 +89,6 @@ export const setSounds = (sounds) => {
 }
 
 export const setUserData = (userData) => {
-  console.log('data ', userData);
   return {
     type: 'SET_USER_DATA',
     userData
@@ -239,5 +245,13 @@ export const setUserFromStorage = (user) => {
   return (dispatch) => {
     dispatch(setUser(user))
     dispatch(fetchUserData(user.id, user.token))
+  }
+}
+
+export const openUserSound = (sound) => {
+  return (dispatch) => {
+    dispatch((setSelectedSound(sound)))
+    dispatch(push('/newsound'))
+
   }
 }

--- a/lib/components/App/index.jsx
+++ b/lib/components/App/index.jsx
@@ -5,6 +5,7 @@ import UserContainer from '../../containers/UserContainer'
 import SequencerContainer from '../../containers/SequencerContainer'
 import Sequencer from '../Sequencer'
 import SoundMakerContainer from '../../containers/SoundMakerContainer'
+import SoundMaker from '../../components/SoundMaker'
 import Header from '../Header'
 import Home from '../Home'
 import CreateNewUser from '../CreateNewUser'
@@ -16,7 +17,7 @@ export class App extends Component {
         <Header />
         <Switch>
           <Route exact path='/' component={Home} />
-          <Route path='/newsound' component={SoundMakerContainer} />
+          <Route path='/newsound' component={SoundMaker} />
           <Route path='/sequencer' component={SequencerContainer} />
           <Route path='/profile/:username' component={UserProfile} />
           <Route path='/sign-up' component={CreateNewUser} />

--- a/lib/components/Sequencer/index.jsx
+++ b/lib/components/Sequencer/index.jsx
@@ -118,7 +118,6 @@ export class Sequencer extends Component {
     Object.assign(soundObject, {sound: soundAttributes})
     let newRack = this.state.trackRacks
     Object.assign(newRack, {[soundAttributes.soundName]:soundObject})
-    console.log(newRack)
     this.setState({ trackRacks: newRack })
   }
 

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -4,6 +4,8 @@ import Select from './Select'
 import Slider from './Slider'
 import update from 'immutability-helper'
 import Button from '../Button'
+import SoundMakerContainer from '../../containers/SoundMakerContainer'
+import UserContainer from '../../containers/UserContainer'
 
 export class SoundMaker extends Component {
   constructor() {
@@ -55,6 +57,14 @@ export class SoundMaker extends Component {
           attack: 0,
         },
       },
+    }
+  }
+
+  componentDidMount() {
+    const { selectedSound } = this.props.userData
+    console.log(selectedSound);
+    if(selectedSound) {
+      this.setState({ spec: selectedSound })
     }
   }
 
@@ -477,4 +487,4 @@ export class SoundMaker extends Component {
   }
 }
 
-export default SoundMaker
+export default UserContainer(SoundMakerContainer(SoundMaker))

--- a/lib/components/UserProfile/index.jsx
+++ b/lib/components/UserProfile/index.jsx
@@ -29,7 +29,6 @@ export class UserProfile extends Component {
                 <button onClick={() => this.props.previewSound(spec)}>Play</button>
                 <button onClick={this.stopSound.bind(this)}>Stop</button>
                 <button onClick={() => this.props.openUserSound(spec)}>Edit</button>
-
             </div>
    })
 }

--- a/lib/components/UserProfile/index.jsx
+++ b/lib/components/UserProfile/index.jsx
@@ -26,8 +26,10 @@ export class UserProfile extends Component {
      let title = spec.soundName ? spec.soundName : 'untitled'
      return <div key={i}>
               <h3 id={sound.id}>Sound: {title}</h3>
-                <button onClick={(e) => this.props.previewSound(spec)}>Play</button>
+                <button onClick={() => this.props.previewSound(spec)}>Play</button>
                 <button onClick={this.stopSound.bind(this)}>Stop</button>
+                <button onClick={() => this.props.openUserSound(spec)}>Edit</button>
+
             </div>
    })
 }

--- a/lib/containers/SoundMakerContainer.jsx
+++ b/lib/containers/SoundMakerContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { previewSound, stopSound, stopAllSounds, saveSound, loadSound } from '../actions'
-import SoundMaker from '../components/SoundMaker'
 
 const mapStateToProps = (state) => {
   return {
@@ -18,4 +17,4 @@ const mapDispatchToProps = {
   loadSound
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SoundMaker)
+export default connect(mapStateToProps, mapDispatchToProps)

--- a/lib/reducers/ActiveUser.js
+++ b/lib/reducers/ActiveUser.js
@@ -12,6 +12,7 @@ const ActiveUser = (state = {}, action) => {
       return stateWithData
     case 'SELECTED_SOUND':
       const selectedSound = Object.assign({}, state, { selectedSound: action.sound })
+      return selectedSound
     default:
       return state
   }

--- a/lib/reducers/ActiveUser.js
+++ b/lib/reducers/ActiveUser.js
@@ -10,6 +10,8 @@ const ActiveUser = (state = {}, action) => {
     case 'SET_USER_DATA':
       const stateWithData = Object.assign({}, state, action.userData)
       return stateWithData
+    case 'SELECTED_SOUND':
+      const selectedSound = Object.assign({}, state, { selectedSound: action.sound })
     default:
       return state
   }


### PR DESCRIPTION
@DanGrund @esayler @dylanavery720 

#### This PR Includes:
* SoundMaker component is now wrapped with the SoundMakerContainer and UserContainer to access props from both
* App renders SoundMaker component instead of container
* `edit` button added to each sound in user profile
* clicking edit on a sound redirects to soundedit view with that sound loaded

#### To Do:
* the view `'/newsound'` should be changed to `'/editsound'` since existing sounds can be modified
* Save sound needs to be modified to ask if user wants to overwrite or save a new sound. 
    * That or we need a delete button so if they do have to create a new sound each time they can delete the old one
* Clicking save or redirecting from newsound view should remove the `selectedSound` prop in state