### PR TITLE
edit loop to fix bug in sequencer

### DIFF
--- a/lib/components/Sequencer/index.jsx
+++ b/lib/components/Sequencer/index.jsx
@@ -68,7 +68,10 @@ export class Sequencer extends Component {
 
   componentWillMount() {
     this.fetchUserData()
-    this.playLoop()
+  }
+
+  componentWillUnmount() {
+    this.loop.stop()
   }
 
   fetchUserData = () => {
@@ -76,28 +79,52 @@ export class Sequencer extends Component {
   }
 
   playPause() {
-    this.setState({ playPause: !this.state.playPause })
+    if (this.loop.isPlaying()) {
+      this.loop.stop()
+    } else {
+      this.loop.start()
+    }
   }
 
-  playLoop() {
-    this.playStep()
-    setTimeout(this.playLoop.bind(this), this.state.spec.tempo)
-  }
+  loop = (() => {
+    let timer
+    let isPlaying = false 
+
+    return {
+      isPlaying: () => {
+        return isPlaying
+      },
+      start: () => {
+        isPlaying = true
+        return this.loop.play()
+      },
+      play: () => {
+        if (isPlaying) {
+          this.playStep()
+          timer = setTimeout(this.loop.play, this.state.spec.tempo)
+          return timer
+        }
+      },
+      stop: () => {
+        isPlaying = false
+        return clearTimeout(timer)
+      },
+    }
+  })()
+
 
   playStep() {
-    if (this.state.playPause) {
-      Object.keys(this.state.spec.trackRacks).forEach((key)=>{
-        if(this.state.spec.trackRacks[key].steps[this.state.currentStep].play && (!this.state.spec.trackRacks[key].mute)){
-          let wad = new Wad (this.state.spec.trackRacks[key].sound)
-          let pitch = (this.state.spec.trackRacks[key].steps[this.state.currentStep].pitch !== '') ? this.state.spec.trackRacks[key].steps[this.state.currentStep].pitch : this.state.spec.trackRacks[key].sound.pitch
-            wad.play({pitch: pitch})
-        }
-      })
-      if (this.state.currentStep < 15) {
-        this.setState({currentStep: this.state.currentStep + 1})
-      } else {
-        this.setState({currentStep: 0})
+    Object.keys(this.state.spec.trackRacks).forEach((key) => {
+      if (this.state.spec.trackRacks[key].steps[this.state.currentStep].play && (!this.state.spec.trackRacks[key].mute)) {
+        let wad = new Wad(this.state.spec.trackRacks[key].sound)
+        let pitch = (this.state.spec.trackRacks[key].steps[this.state.currentStep].pitch !== '') ? this.state.spec.trackRacks[key].steps[this.state.currentStep].pitch : this.state.spec.trackRacks[key].sound.pitch
+        wad.play({ pitch: pitch })
       }
+    })
+    if (this.state.currentStep < 15) {
+      this.setState({ currentStep: this.state.currentStep + 1 })
+    } else {
+      this.setState({ currentStep: 0 })
     }
   }
 


### PR DESCRIPTION
### Changes:

- made a bunch of changes to the structure/mechanism of how we **start** and **stop** loops using the magic of _closure_ and _IIFE_ 🥇 
- no more `setState()` error on navigation away from sequencer page, recursive calls stop 😃 
- sequencer should stop recursive calls when you toggle the play button
- **how?** sequencer doesn't start a loop on mount, instead, loop only starts and stops when you click the "Play" button. I think this is better for performance too.

### TODO:
1.  fix play button to toggle between "play/pause" since we stopped utilizing/changing `this.state.playPause`
2. fix warning about `select` syntax when `soundMaker` and `sequencer` mount