### PR TITLE
Sound name ml 

### DIFF
--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -66,10 +66,14 @@ export class SoundMaker extends Component {
   componentDidMount() {
     const { selectedSound } = this.props.userData
     if (selectedSound) {
-      this.setState({ spec: selectedSound }, () => {
-        this.props.setSelectedSound({}, null)
-      })
+      console.log('hit!!!');
+      this.setState({ spec: selectedSound })
     }
+  }
+
+  componentWillUnmount() {
+    this.props.setSelectedSound(null, null)
+    this.props.editSound(null, null)
   }
 
   round(number, decimals) {

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -7,6 +7,7 @@ import Button from '../Button'
 import './sound-maker.scss'
 import SoundMakerContainer from '../../containers/SoundMakerContainer'
 import UserContainer from '../../containers/UserContainer'
+import InlineEdit from 'react-edit-inline'
 
 export class SoundMaker extends Component {
   constructor() {
@@ -14,7 +15,7 @@ export class SoundMaker extends Component {
     this.round = this.round.bind(this)
     this.state = {
       savedchanges: true,
-      newSoundName: '',
+      soundName: '',
       spec: {
         source: 'sine',
         volume: 0.5,
@@ -65,7 +66,9 @@ export class SoundMaker extends Component {
   componentDidMount() {
     const { selectedSound } = this.props.userData
     if (selectedSound) {
-      this.setState({ spec: selectedSound })
+      this.setState({ spec: selectedSound }, () => {
+        this.props.setSelectedSound({}, null)
+      })
     }
   }
 
@@ -111,8 +114,8 @@ export class SoundMaker extends Component {
   }
 
   checkForName = () => {
-    const { newSoundName } = this.state
-    return newSoundName ? newSoundName : prompt('What do you want to call your sound')
+    const { soundName } = this.state
+    return soundName ? soundName : prompt('What do you want to call your sound')
   }
 
   fetchType(method, sound_id = null) {
@@ -233,13 +236,18 @@ export class SoundMaker extends Component {
           }
         </div>
         {this.state.spec.soundName ?
-          <div className='sound-name' contentEditable>
-            {this.state.spec.soundName}
+          <div className='sound-name'>
+            <InlineEdit text={this.state.spec.soundName}
+                        paramName='editedName'
+                        change={(e) => this.setState({ soundName: e.editedName })} />
+
           </div>
+
+
           :
           <div className='sound-name'>
             <input placeholder='Name This Sound'
-                   onChange={(e) => {this.setState({ newSoundName: e.target.value })}}/>
+                   onChange={(e) => {this.setState({ soundName: e.target.value })}}/>
           </div>
         }
 

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -14,6 +14,7 @@ export class SoundMaker extends Component {
     this.round = this.round.bind(this)
     this.state = {
       savedchanges: true,
+      newSoundName: '',
       spec: {
         source: 'sine',
         volume: 0.5,
@@ -109,8 +110,13 @@ export class SoundMaker extends Component {
       return username ? this.fetchType('POST') : alert('Please Sign In')
   }
 
+  checkForName = () => {
+    const { newSoundName } = this.state
+    return newSoundName ? newSoundName : prompt('What do you want to call your sound')
+  }
+
   fetchType(method, sound_id = null) {
-    let soundName = prompt('What do you want to call your sound')
+    let soundName = this.checkForName()
     let fType = this.setState(update(this.state, { spec: { soundName: { $set: soundName } } }), () => this.props.saveSound(JSON.stringify(this.state.spec), this.props.user.id, method , sound_id))
     this.setState({ savedchanges: true })
   }
@@ -120,7 +126,6 @@ export class SoundMaker extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // console.log(nextProps)
     if(nextProps.sound.id !== this.props.sound.id) {
       this.setState({spec: nextProps.sound.editsound, id: nextProps.sound.id})
     }
@@ -211,7 +216,8 @@ export class SoundMaker extends Component {
           message='You have unsaved changes that will be lost. Are you sure want to leave?'
         />
         {!this.state.savedchanges && <div className='msg'>You have unsaved changes.</div>}
-        {this.state.spec.soundName && <div className='sound-name'>{this.state.spec.soundName}</div>}
+        <div>
+        </div>
         <div className='btn-group'>
           <Button className='btn btn-play' text='Play' handleClick={this.previewSound} />
           <Button className='btn btn-stop' text='Stop' handleClick={this.stopSound} />
@@ -226,8 +232,18 @@ export class SoundMaker extends Component {
             </label>
           }
         </div>
+        {this.state.spec.soundName ?
+          <div className='sound-name' contentEditable>
+            {this.state.spec.soundName}
+          </div>
+          :
+          <div className='sound-name'>
+            <input placeholder='Name This Sound'
+                   onChange={(e) => {this.setState({ newSoundName: e.target.value })}}/>
+          </div>
+        }
 
-        <div className='basics'>
+        <div className='basics edit-section'>
           <Select
             name='source-shape'
             className='select source-shape'
@@ -268,7 +284,7 @@ export class SoundMaker extends Component {
           <input name='pitch' placeholder='pitch A0-C8' type='text' value={this.state.spec.pitch} onChange={this.updatePitch} />
           <br />
         </div>
-        <div className='ADSR'>
+        <div className='ADSR edit-section'>
           <h4> ADSR </h4>
           <Slider
             label='Attack'
@@ -321,7 +337,7 @@ export class SoundMaker extends Component {
             value={this.state.spec.env.release}
           />
         </div>
-        <div className='filter'>
+        <div className='filter edit-section'>
           <h4> Filter </h4>
           <Select
             name='filter-type'
@@ -369,7 +385,7 @@ export class SoundMaker extends Component {
             value={this.state.spec.filter.env.attack}
           />
         </div>
-        <div className='reverb'>
+        <div className='reverb edit-section'>
           <h4> Reverb </h4>
           <Select
             name='select-reverb-impulse'
@@ -426,7 +442,7 @@ export class SoundMaker extends Component {
             value={this.state.spec.reverb.wet}
           />
         </div>
-          <div className='delay'>
+          <div className='delay edit-section'>
             <h4> Delay </h4>
             <Slider
               label='Time'
@@ -459,7 +475,7 @@ export class SoundMaker extends Component {
               value={this.state.spec.delay.feedback}
             />
           </div>
-          <div className='vibrato'>
+          <div className='vibrato edit-section'>
             <h4> Vibrato </h4>
             <Select
               name='vibrato-shape'
@@ -498,7 +514,7 @@ export class SoundMaker extends Component {
               value={this.state.spec.vibrato.attack}
             />
           </div>
-          <div className='tremolo'>
+          <div className='tremolo edit-section'>
             <h4> Tremolo </h4>
             <Select
               name='tremolo-shape'

--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -212,6 +212,21 @@ export class SoundMaker extends Component {
       }
     }
 
+    const toggleSoundName = () => {
+      return this.state.spec.soundName
+      ?
+      <div className='sound-name'>
+        <InlineEdit text={this.state.spec.soundName}
+                    paramName='editedName'
+                    change={(e) => this.setState({ soundName: e.editedName })} />
+      </div>
+      :
+      <div className='sound-name'>
+        <input placeholder='Name This Sound'
+               onChange={(e) => {this.setState({ soundName: e.target.value })}}/>
+      </div>
+    }
+
     return (
       <div className='sound-maker-container'>
         <Prompt
@@ -235,21 +250,7 @@ export class SoundMaker extends Component {
             </label>
           }
         </div>
-        {this.state.spec.soundName ?
-          <div className='sound-name'>
-            <InlineEdit text={this.state.spec.soundName}
-                        paramName='editedName'
-                        change={(e) => this.setState({ soundName: e.editedName })} />
-
-          </div>
-
-
-          :
-          <div className='sound-name'>
-            <input placeholder='Name This Sound'
-                   onChange={(e) => {this.setState({ soundName: e.target.value })}}/>
-          </div>
-        }
+        {toggleSoundName()}
 
         <div className='basics edit-section'>
           <Select

--- a/lib/components/SoundMaker/sound-maker.scss
+++ b/lib/components/SoundMaker/sound-maker.scss
@@ -3,7 +3,7 @@
 .sound-maker-container {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
-  grid-template-rows: 10px 50px 25px 1fr 1fr 1fr 1fr;
+  grid-template-rows: 10px 50px 50px 1fr 1fr 1fr 1fr;
   grid-column-gap: 15px;
   grid-row-gap: 5px;
   justify-items: center;
@@ -12,7 +12,7 @@
 
   .btn-new {
     width: 110px;
-  } 
+  }
 
   label.select-load-sound:after {
     position: absolute;
@@ -27,7 +27,7 @@
 
 .msg {
   align-items: center;
-  grid-column: 2 / 4;
+  grid-column: 3 / 5;
   grid-row: 2 / 3;
   text-align: center;
   color: $info-msg-text-color;
@@ -36,10 +36,12 @@
 }
 
 .sound-name {
-  grid-column: 4 / 5;
-  grid-row: 2 / 3;
+  display: flex;
+  grid-column: 2 / 4;
+  grid-row: 3 / 4;
   text-align: center;
   justify-content: center;
+  font-size: 2.7em;
 }
 
 .btn-group {
@@ -94,15 +96,14 @@
 
   .msg {
     align-items: center;
-    grid-column: 2 / 4;
-    grid-row: 3 / 4; 
-    justify-content: center;
-   
-  }
-  
-  .sound-name {
-    grid-column: 2 / 3;
+    grid-column: 3 / 5;
     grid-row: 2 / 3;
+    justify-content: center;
+  }
+
+  .sound-name {
+    grid-column: 2 / 4;
+    grid-row: 3;
     text-align: center;
     justify-content: center;
   }
@@ -121,27 +122,27 @@
     grid-column: 3 / 4;
     grid-row: 4 / 5;
   }
-  
+
   .filter {
     grid-column: 2 / 3;
     grid-row: 5 / 6;
   }
-  
+
   .vibrato {
     grid-column: 3 / 4;
     grid-row: 5 / 6;
   }
-  
+
   .tremolo {
     grid-column: 2 / 3;
     grid-row: 6 / 7;
   }
-  
+
   .delay {
     grid-column: 3 / 4;
     grid-row: 6 / 7;
   }
-  
+
   .reverb {
     grid-column: 2 / 4;
     grid-row: 7 / 8;
@@ -153,27 +154,27 @@
 @media (max-width: 900px) {
   .sound-maker-container {
     grid-template-columns: 1fr 3fr 1fr;
-    
-   
+
+
 
     .select {
       font-size: 12px;
     }
-  } 
+  }
 
- 
+
 
    .msg {
     align-items: center;
-    grid-column: 2 / 3;
-    grid-row: 3 / 4; 
+    grid-column: 3 / 5;
+    grid-row: 2 / 3;
     justify-content: center;
-   
+
   }
-  
+
   .sound-name {
     grid-column: 2 / 3;
-    grid-row: 2 / 3;
+    grid-row: 3 / 3;
     text-align: center;
     justify-content: center;
   }
@@ -195,27 +196,27 @@
     grid-column: 2 / 3;
     grid-row: 5 / 6;
   }
-  
+
   .filter {
     grid-column: 2 / 3;
     grid-row: 6 / 7;
   }
-  
+
   .vibrato {
     grid-column: 2 / 3;
     grid-row: 7 / 8;
   }
-  
+
   .tremolo {
     grid-column: 2 / 3;
     grid-row: 8 / 9;
   }
-  
+
   .delay {
     grid-column: 2 / 3;
     grid-row: 9 / 10;
   }
-  
+
   .reverb {
     grid-column: 2 / 3;
     grid-row: 10 / 11;
@@ -239,5 +240,5 @@
     .btn-new {
       width: 80px;
     }
-  } 
+  }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-dom": "^15.4.2",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-onclickoutside": "^5.11.1",
+    "react-edit-inline": "^1.0.8",
     "react-redux": "^5.0.3",
     "react-router-redux": "^5.0.0-alpha.4",
     "react-toggle": "^3.0.1",


### PR DESCRIPTION
## Don't forget to npm install @dylanavery720 @DanGrund @esayler 

#### This PR Includes:
* a new npm module `<InlineEdit>` that displays the sound name but clicking it you can edit it and spit out an object with the new name to save the updated name
* Directing to the SoundMaker view to edit a sound will show sound name
    * Otherwise an input appears to name the new sound
* New function to check whether or not a new name is provided and pops up an alert if not (otherwise no alert is seen)
* Modified spacing above edit sound controls to make room for input/sound name
* After sound to be edited is set in state, I set the `selectedSound` and `editsound` props from store to null so when you direct away and back to SoundMaker it populates a new sound template

#### To Do:
* Need to handle the unsaved progress prompt...sits behind input so put to the right for now (issue created)
* Save button is prompting me to login with alert