### PR TITLE
fix reverb spelling

### DIFF
--- a/lib/components/SoundMaker/index.jsx
+++ b/lib/components/SoundMaker/index.jsx
@@ -418,7 +418,7 @@ export class SoundMaker extends Component {
               'CementBlocks1',
               'CementBlocks2',
               'ChateaudeLogneOutside',
-              'ConcLongEchoHall',
+              'ConicLongEchoHall',
               'DeepSpace',
               'DerlonSanctuary',
               'DirectCabinetN1',


### PR DESCRIPTION
- fix a bug where reverb was misspelled would crash the app
`TODO:` handle not found error on server side